### PR TITLE
AP-11152 Fix exam start crash on Moodle < 3.11 (profile field get_shortname)

### DIFF
--- a/classes/client.php
+++ b/classes/client.php
@@ -297,7 +297,9 @@ class client {
 
         $special = null;
         foreach(profile_get_user_fields_with_data($user->id) as $field) {
-            if($field->get_shortname() != "proctor_special_accommodations") {
+            // Use the record property instead of get_shortname(): the getter
+            // only exists since Moodle 3.11 and fatals on older versions.
+            if($field->field->shortname != "proctor_special_accommodations") {
                 continue;
             }
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'availability_proctor';
-$plugin->version = 2026030500;
-$plugin->release = 'v2.6';
+$plugin->version = 2026070200;
+$plugin->release = 'v2.7';
 $plugin->requires = 2018111800;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
## Problem

Starting a proctored exam on Moodle < 3.11 (reported on 3.10.3) fails with:

`Exception - Call to undefined method profile_field_text::get_shortname()`

`client.php` `user_data()` reads the `proctor_special_accommodations` profile
field via `profile_field_base::get_shortname()`, but that getter only exists
since Moodle 3.11. Introduced with the special-accommodations feature
(8ea826c, shipped in v2.5), so every v2.5+ release crashes exam start on
older Moodle. Our docs and `version.php` (`requires = 2018111800`, Moodle 3.6+)
both advertise support for these versions.

## Fix

Read the shortname via the field record property `$field->field->shortname`,
which is available on all supported Moodle versions (3.6–4.x/5.x) —
`get_shortname()` itself is just an accessor for this property.

Bump plugin version to v2.7 (2026070200).

## Testing

- PHP syntax check on changed files
- Planned per agreed flow (YouTrack AP-11152): install on our Moodle dev →
  run regression → deliver the fixed plugin to the client (Moodle 3.10.3)