### PR TITLE
Add local Moodle dev stand (docker compose, Moodle 3.10-5.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ releases
 .DS_Store
 .cursor
 openspec
+dev/.moodle

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,71 @@
+# Local Moodle dev stand
+
+Run any supported Moodle version locally with one command, with the Proctor
+plugin mounted from the working tree. Settings, courses, users, and the
+integration config **persist across restarts** — data lives in named Docker
+volumes and `config.php` inside the per-version source clone.
+
+## Requirements
+
+- Docker with Compose v2
+- ~1 GB of disk per Moodle version (source clone + DB + moodledata)
+
+## Quick start
+
+```bash
+cd dev
+./moodle.sh up 310        # Moodle 3.10 at http://localhost:8310
+./moodle.sh up 500        # Moodle 5.0  at http://localhost:8500
+```
+
+First run per version: clones Moodle sources (shallow), starts MariaDB +
+Apache/PHP, installs Moodle via CLI, and registers the plugin. Subsequent
+runs just start the containers — everything you configured is still there.
+
+Admin login: `admin` / `Test-1234`
+
+## Version matrix
+
+| Key | Moodle | PHP | MariaDB | URL |
+|-----|--------|-----|---------|-----|
+| 310 | 3.10 (client-reported) | 7.4 | 10.5 | http://localhost:8310 |
+| 311 | 3.11 (first with `get_shortname()`) | 7.4 | 10.5 | http://localhost:8311 |
+| 405 | 4.5 LTS | 8.2 | 10.11 | http://localhost:8405 |
+| 500 | 5.0 | 8.3 | 10.11 | http://localhost:8500 |
+
+Versions can run simultaneously — ports and volumes do not overlap.
+
+## Commands
+
+```bash
+./moodle.sh up <ver>            # start (installs on first run)
+./moodle.sh up <ver> --clean    # start WITHOUT the plugin mount (zip-install testing)
+./moodle.sh down <ver>          # stop, keep all data
+./moodle.sh reset <ver>         # stop and DELETE all data (asks for confirmation)
+./moodle.sh ps                  # container status
+./moodle.sh urls                # URLs and credentials
+```
+
+## How the plugin is delivered
+
+Default mode bind-mounts the repo root into
+`availability/condition/proctor` in every Moodle. Code edits are visible
+immediately; after changing PHP classes purge caches
+(*Site administration → Development → Purge caches*). Version bumps in
+`version.php` trigger the normal Moodle upgrade flow on next admin visit.
+
+`--clean` mode skips the mount so you can exercise the real client install
+path: build a zip (`make release-docker` in the repo root) and upload it via
+*Site administration → Plugins → Install plugins*.
+
+## Notes
+
+- Proctor integration settings (name/secret/account) are not preconfigured —
+  set what you need in *Admin → Plugins → Availability restrictions →
+  Proctor* exactly like on a real installation. Outbound calls to a Proctor
+  API work from localhost; callbacks from a remote Proctor to your local
+  Moodle will not reach it.
+- Moodle source clones live in `dev/.moodle/<ver>` (gitignored). They are
+  shadowed inside the container's plugin directory via tmpfs, so Moodle
+  never scans them.
+- To wipe one version and start fresh: `./moodle.sh reset <ver>`.

--- a/dev/compose.plugin.yaml
+++ b/dev/compose.plugin.yaml
@@ -1,0 +1,31 @@
+# Overlay: live-mount the plugin working tree into each Moodle.
+# Applied by dev/moodle.sh unless --clean is passed.
+#
+# The repo root is mounted as availability/condition/proctor. The dev/
+# subdirectory (which contains the multi-hundred-MB Moodle source clones)
+# is shadowed with a tmpfs so Moodle never walks into it.
+
+services:
+  web310:
+    volumes:
+      - ..:/var/www/html/availability/condition/proctor
+    tmpfs:
+      - /var/www/html/availability/condition/proctor/dev
+
+  web311:
+    volumes:
+      - ..:/var/www/html/availability/condition/proctor
+    tmpfs:
+      - /var/www/html/availability/condition/proctor/dev
+
+  web405:
+    volumes:
+      - ..:/var/www/html/availability/condition/proctor
+    tmpfs:
+      - /var/www/html/availability/condition/proctor/dev
+
+  web500:
+    volumes:
+      - ..:/var/www/html/availability/condition/proctor
+    tmpfs:
+      - /var/www/html/availability/condition/proctor/dev

--- a/dev/compose.yaml
+++ b/dev/compose.yaml
@@ -1,0 +1,135 @@
+# Local Moodle dev stand for the Proctor availability plugin.
+#
+# Each Moodle version is a compose profile with its own DB and moodledata
+# volumes, so settings and data persist across restarts. Use dev/moodle.sh —
+# it clones Moodle sources on first run and performs the CLI install.
+#
+# Profiles:  310  311  405  500
+# Ports:     8310 8311 8405 8500
+
+services:
+  db310:
+    image: mariadb:10.5
+    profiles: ["310"]
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    environment:
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_DATABASE: moodle
+      MARIADB_USER: moodle
+      MARIADB_PASSWORD: moodle
+    volumes:
+      - dbdata310:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  web310:
+    image: moodlehq/moodle-php-apache:7.4
+    profiles: ["310"]
+    depends_on:
+      db310:
+        condition: service_healthy
+    ports:
+      - "8310:80"
+    volumes:
+      - ./.moodle/310:/var/www/html
+      - moodledata310:/var/www/moodledata
+
+  db311:
+    image: mariadb:10.5
+    profiles: ["311"]
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    environment:
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_DATABASE: moodle
+      MARIADB_USER: moodle
+      MARIADB_PASSWORD: moodle
+    volumes:
+      - dbdata311:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  web311:
+    image: moodlehq/moodle-php-apache:7.4
+    profiles: ["311"]
+    depends_on:
+      db311:
+        condition: service_healthy
+    ports:
+      - "8311:80"
+    volumes:
+      - ./.moodle/311:/var/www/html
+      - moodledata311:/var/www/moodledata
+
+  db405:
+    image: mariadb:10.11
+    profiles: ["405"]
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    environment:
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_DATABASE: moodle
+      MARIADB_USER: moodle
+      MARIADB_PASSWORD: moodle
+    volumes:
+      - dbdata405:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  web405:
+    image: moodlehq/moodle-php-apache:8.2
+    profiles: ["405"]
+    depends_on:
+      db405:
+        condition: service_healthy
+    ports:
+      - "8405:80"
+    volumes:
+      - ./.moodle/405:/var/www/html
+      - moodledata405:/var/www/moodledata
+
+  db500:
+    image: mariadb:10.11
+    profiles: ["500"]
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    environment:
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_DATABASE: moodle
+      MARIADB_USER: moodle
+      MARIADB_PASSWORD: moodle
+    volumes:
+      - dbdata500:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  web500:
+    image: moodlehq/moodle-php-apache:8.3
+    profiles: ["500"]
+    depends_on:
+      db500:
+        condition: service_healthy
+    ports:
+      - "8500:80"
+    volumes:
+      - ./.moodle/500:/var/www/html
+      - moodledata500:/var/www/moodledata
+
+volumes:
+  dbdata310:
+  moodledata310:
+  dbdata311:
+  moodledata311:
+  dbdata405:
+  moodledata405:
+  dbdata500:
+  moodledata500:

--- a/dev/moodle.sh
+++ b/dev/moodle.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Local Moodle dev stand for the Proctor availability plugin.
+#
+# One command per Moodle version; settings, courses, and integration config
+# persist across restarts (named volumes + config.php in the source clone).
+#
+# Usage:
+#   ./moodle.sh up <version> [--clean]   start (clone + install on first run)
+#   ./moodle.sh down <version>           stop, keep all data
+#   ./moodle.sh reset <version>          stop and DELETE all data for version
+#   ./moodle.sh ps                       show stand status
+#   ./moodle.sh urls                     print URLs and credentials
+#
+# Versions: 310 (Moodle 3.10, PHP 7.4), 311 (3.11, PHP 7.4),
+#           405 (4.5, PHP 8.2), 500 (5.0, PHP 8.3)
+#
+# --clean: do not mount the plugin working tree (for testing zip installs
+#          through the admin UI, like a real client).
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+ADMIN_USER="admin"
+ADMIN_PASS="Test-1234"
+MOODLE_GIT="https://github.com/moodle/moodle.git"
+
+branch_for() {
+  case "$1" in
+    310) echo "MOODLE_310_STABLE" ;;
+    311) echo "MOODLE_311_STABLE" ;;
+    405) echo "MOODLE_405_STABLE" ;;
+    500) echo "MOODLE_500_STABLE" ;;
+    *) echo "Unknown version: $1 (use 310|311|405|500)" >&2; return 1 ;;
+  esac
+}
+
+port_for() {
+  case "$1" in
+    310) echo 8310 ;;
+    311) echo 8311 ;;
+    405) echo 8405 ;;
+    500) echo 8500 ;;
+  esac
+}
+
+compose() {
+  local ver="$1" clean="$2"; shift 2
+  local files=(-f compose.yaml)
+  if [ "$clean" != "1" ]; then
+    files+=(-f compose.plugin.yaml)
+  fi
+  docker compose "${files[@]}" --profile "$ver" "$@"
+}
+
+ensure_sources() {
+  local ver="$1"
+  local branch; branch="$(branch_for "$ver")"
+  if [ ! -f ".moodle/$ver/version.php" ]; then
+    echo ">> Cloning Moodle $branch (shallow) into dev/.moodle/$ver ..."
+    mkdir -p .moodle
+    git clone --depth 1 --branch "$branch" "$MOODLE_GIT" ".moodle/$ver"
+  fi
+}
+
+install_if_needed() {
+  local ver="$1"
+  local port; port="$(port_for "$ver")"
+  if [ -f ".moodle/$ver/config.php" ]; then
+    echo ">> config.php exists — skipping install (data persisted)"
+    return 0
+  fi
+  echo ">> First run: installing Moodle $ver (this takes a couple of minutes)..."
+  docker compose -f compose.yaml --profile "$ver" exec -T -u root "web$ver" \
+    chown -R www-data:www-data /var/www/moodledata
+  docker compose -f compose.yaml --profile "$ver" exec -T -u www-data "web$ver" \
+    php admin/cli/install.php \
+      --lang=en \
+      --wwwroot="http://localhost:$port" \
+      --dataroot=/var/www/moodledata \
+      --dbtype=mariadb \
+      --dbhost="db$ver" \
+      --dbname=moodle \
+      --dbuser=moodle \
+      --dbpass=moodle \
+      --prefix=mdl_ \
+      --fullname="Moodle $ver — Proctor plugin dev" \
+      --shortname="m$ver" \
+      --summary="" \
+      --adminuser="$ADMIN_USER" \
+      --adminpass="$ADMIN_PASS" \
+      --adminemail="admin@example.com" \
+      --agree-license \
+      --non-interactive
+  echo ">> Registering installed plugins (upgrade.php)..."
+  docker compose -f compose.yaml --profile "$ver" exec -T -u www-data "web$ver" \
+    php admin/cli/upgrade.php --non-interactive || true
+}
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  up)
+    ver="${1:?version required (310|311|405|500)}"; shift || true
+    clean=0
+    [ "${1:-}" = "--clean" ] && clean=1
+    branch_for "$ver" >/dev/null
+    ensure_sources "$ver"
+    compose "$ver" "$clean" up -d
+    install_if_needed "$ver"
+    port="$(port_for "$ver")"
+    echo ""
+    echo "Moodle $ver is up: http://localhost:$port  ($ADMIN_USER / $ADMIN_PASS)"
+    if [ "$clean" = "1" ]; then
+      echo "Clean mode: plugin NOT mounted — install a zip via Site administration > Plugins."
+    else
+      echo "Plugin mounted live from the working tree (availability/condition/proctor)."
+      echo "After code changes: Site administration > Development > Purge caches."
+    fi
+    ;;
+  down)
+    ver="${1:?version required}"
+    compose "$ver" 0 down
+    echo "Stopped Moodle $ver. Data kept — './moodle.sh up $ver' resumes where you left off."
+    ;;
+  reset)
+    ver="${1:?version required}"
+    read -r -p "Delete ALL data for Moodle $ver (DB, moodledata, config.php)? [y/N] " ans
+    if [ "${ans:-n}" = "y" ]; then
+      compose "$ver" 0 down -v || true
+      rm -f ".moodle/$ver/config.php"
+      echo "Moodle $ver wiped. Next 'up' performs a fresh install."
+    else
+      echo "Cancelled."
+    fi
+    ;;
+  ps)
+    docker compose -f compose.yaml --profile 310 --profile 311 --profile 405 --profile 500 ps
+    ;;
+  urls)
+    for v in 310 311 405 500; do
+      echo "Moodle $v: http://localhost:$(port_for "$v")  ($ADMIN_USER / $ADMIN_PASS)"
+    done
+    ;;
+  *)
+    sed -n '2,17p' "$0" | sed 's/^# \{0,1\}//'
+    exit 1
+    ;;
+esac

--- a/utils/release.py
+++ b/utils/release.py
@@ -88,7 +88,7 @@ def ask_yes_no(question, default='y'):
 
 def run(name='proctor', dry=False, verbose=False, force=False):
     # List project files
-    ignore_files = [ 'releases', 'utils', 'node_modules', '.git', 'openspec', '.cursor']
+    ignore_files = [ 'releases', 'utils', 'node_modules', '.git', 'openspec', '.cursor', 'dev']
     append_files = ['.htaccess',]
 
     output_dir = f'releases/{name}/'


### PR DESCRIPTION
## What

One-command local Moodle environments for manual plugin testing, with state
that persists across restarts:

    cd dev
    ./moodle.sh up 310     # Moodle 3.10 -> http://localhost:8310
    ./moodle.sh up 500     # Moodle 5.0  -> http://localhost:8500

## Version matrix

| Key | Moodle | PHP | MariaDB | Port |
|-----|--------|-----|---------|------|
| 310 | 3.10 (client-reported, AP-11152) | 7.4 | 10.5 | 8310 |
| 311 | 3.11 (first with `get_shortname()`) | 7.4 | 10.5 | 8311 |
| 405 | 4.5 LTS | 8.2 | 10.11 | 8405 |
| 500 | 5.0 | 8.3 | 10.11 | 8500 |

All versions can run simultaneously — separate ports and volumes.

## How it works

- Official `moodlehq/moodle-php-apache` images (arm64/amd64), one PHP tag per
  Moodle version; MariaDB pinned per version
- Moodle sources are shallow-cloned into `dev/.moodle/<ver>` on first run
  (gitignored); CLI install runs once, then `config.php` + named volumes keep
  all settings, courses, and integration config across restarts
- The plugin working tree is live-mounted into
  `availability/condition/proctor` — code edits visible after cache purge;
  `--clean` starts without the mount for real zip-install testing
- `./moodle.sh reset <ver>` wipes one version after confirmation
- `dev/` is excluded from release packaging (`release.py` ignore list)

## Testing

Smoke-tested on Moodle 3.10 (arm64): fresh install registers
`availability_proctor`, web responds, `down`/`up` resumes with data intact;
plugin v2.7 (AP-11152 fix) installs on 3.10 without fatals.