### PR TITLE
AP-11908: apply merged rule defaults to stored quiz restrictions

### DIFF
--- a/classes/condition.php
+++ b/classes/condition.php
@@ -257,7 +257,7 @@ class condition extends \core_availability\condition {
 
         if (!empty($structure->rules)) {
             $rules = array_merge(self::RULES, (array)$structure->rules);
-            $this->rules = $structure->rules;
+            $this->rules = (object)$rules;
         } else {
             $this->rules = (object)self::RULES;
         }


### PR DESCRIPTION
In `condition::__construct` the merged rule array was computed and then thrown away:

```php
$rules = array_merge(self::RULES, (array)$structure->rules);
$this->rules = $structure->rules;   // merged $rules discarded
```

A quiz whose proctoring restriction was saved earlier therefore keeps exactly the rule set stored back then. Any rule added to the plugin afterwards is missing from the payload sent to Proctor until a teacher opens the restriction and saves it again. `warnings` immediately above and `scoring` immediately below already assign their merged result — this brings `rules` in line with both.

Checked before shipping:

- a rule the teacher deliberately turned off is not re-enabled: `array_merge(self::RULES, …)` gives the later array precedence, so a stored `false` wins over a `true` default such as `allow_to_use_paper` or `allow_to_use_calculator`
- `validate()` strips keys outside `RULES` and casts the rest to bool, so the merge cannot introduce unexpected keys
- the availability JSON stored for a module does grow on the next save, because `save()` serialises the full set. Teacher saves through the UI already submit every rendered checkbox, so this only makes programmatic paths match the UI
- no reader depends on the sparse shape: `to_json()`, `save()` and `client::exam_data()` all take the whole rules object, and `is_available()` does not look at rules at all

Shipping on its own, ahead of the new exam option, so the fix can be reviewed and released without waiting for the feature.
